### PR TITLE
Add unified main menu

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -1,26 +1,16 @@
-import { Context, Markup } from 'telegraf';
+import { Context } from 'telegraf';
 import User from '../../db/models/User';
 import { v4 as uuidv4 } from 'uuid';
 import { createVpnClient } from '../../services/xuiService';
 import logger from '../../logger';
+import { mainMenu, guideLink } from '../menu';
 
 export async function startCommand(ctx: Context) {
-  const guideLink = `https://dkurokhtin.github.io/vpn-docs/#/`
   const telegramId = ctx.from?.id;
   const username = ctx.from?.username || `user_${telegramId}`;
   if (!telegramId) return ctx.reply("Ошибка: не удалось получить ваш Telegram ID");
 
   let user = await User.findOne({ telegramId });
-await User.updateOne(
-        { telegramId: 394971301 },
-        {
-          $set: {
-            subscriptionEndsAt: new Date(Date.now() - 60 * 1000),
-            disabled: false,
-            notifiedExpired: false
-          }
-        }
-      );
   if (user) {
     
     return ctx.reply(
@@ -30,11 +20,7 @@ await User.updateOne(
         `\`\`\`\n${user.vpnConfigUrl}\n\`\`\``,
         {
           parse_mode: 'Markdown',
-          ...Markup.inlineKeyboard([
-            [Markup.button.callback('📊 Статус', 'status')],
-            [Markup.button.callback('🔁 Продлить подписку', 'extend')],
-            [Markup.button.url('📖 Инструкция', guideLink)]
-          ])
+          ...mainMenu()
         }
       );
     
@@ -61,10 +47,10 @@ await User.updateOne(
         `🗓️ Подписка активна 7 дней.\n\n` +
         `🔗 Ваша VPN-ссылка (скопируйте вручную):\n\`\`\`\n${vpnLink}\n\`\`\`\n\n` +
         `⚙️ Инструкция по подключению для iPhone:\n${guideLink}`,
-        { parse_mode: 'Markdown', ...Markup.inlineKeyboard([
-            [Markup.button.callback('⚙️ Статус', 'status')],
-            [Markup.button.url('📖 Инструкция', guideLink)]
-          ])}
+        {
+          parse_mode: 'Markdown',
+          ...mainMenu()
+        }
       );
   } catch (error: any) {
     logger.error('❌ Ошибка при создании клиента в XUI:', error.message);

--- a/src/bot/commands/status.ts
+++ b/src/bot/commands/status.ts
@@ -1,11 +1,10 @@
 import { Context } from 'telegraf';
 import User from '../../db/models/User';
-import { Markup } from 'telegraf';
+import { mainMenu, guideLink } from '../menu';
 
 export async function statusCommand(ctx: Context) {
   const telegramId = ctx.from?.id;
   const username = ctx.from?.username || `user_${telegramId}`;
-  const guideLink = 'https://dkurokhtin.github.io/vpn-docs/#/';
 
   if (!telegramId) {
     return ctx.reply('❌ Ошибка: не удалось определить ваш Telegram ID');
@@ -36,11 +35,7 @@ export async function statusCommand(ctx: Context) {
     `🔗 Ваша VPN-ссылка:\n\`\`\`\n${user.vpnConfigUrl}\n\`\`\``,
     {
       parse_mode: 'Markdown',
-      ...Markup.inlineKeyboard([
-        [{text:'🔁 Продлить', callback_data:'extend'}],
-        [{ text: '📲 Получить QR-код', callback_data: 'get_qr' }],
-        [Markup.button.url('📖 Инструкция', guideLink)]
-      ])
+      ...mainMenu()
     }
   );
 }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -9,6 +9,7 @@ import { qrCommand } from './commands/qr';
 
 
 import { extendCommand } from './commands/extend';
+import { mainMenu } from './menu';
 
 import logger from '../logger';
 import wrapCallbackAction from '../utils/wrapCallbackAction';
@@ -22,6 +23,14 @@ export function registerActions(bot: Telegraf<any>) {
   }
 dotenv.config();
 export const bot = new Telegraf(process.env.BOT_TOKEN!);
+bot.telegram.setMyCommands([
+  { command: 'start', description: 'Начать работу' },
+  { command: 'status', description: 'Статус подписки' },
+  { command: 'get_qr', description: 'Получить QR-код' },
+  { command: 'config', description: 'Получить конфиг' },
+  { command: 'extend', description: 'Продлить подписку' },
+  { command: 'balance', description: 'Баланс' }
+]);
 
  // Лог всех входящих апдейтов (сообщения, команды, кнопки)
 bot.use((ctx, next) => {

--- a/src/bot/menu.ts
+++ b/src/bot/menu.ts
@@ -1,0 +1,12 @@
+import { Markup } from 'telegraf';
+
+export const guideLink = 'https://dkurokhtin.github.io/vpn-docs/#/';
+
+export function mainMenu() {
+  return Markup.inlineKeyboard([
+    [{ text: '🧾 Статус', callback_data: 'status' }],
+    [{ text: '📲 Получить QR-код', callback_data: 'get_qr' }],
+    [{ text: '🔁 Продлить подписку', callback_data: 'extend' }],
+    [Markup.button.url('📖 Инструкция', guideLink)]
+  ]);
+}

--- a/src/utils/sendVpnConfigInfo.ts
+++ b/src/utils/sendVpnConfigInfo.ts
@@ -1,5 +1,6 @@
-import { Context, Markup } from 'telegraf';
+import { Context } from 'telegraf';
 import QRCode from 'qrcode';
+import { mainMenu, guideLink } from '../bot/menu';
 
 export async function sendVpnConfigInfo(
     ctx: Context,
@@ -9,7 +10,6 @@ export async function sendVpnConfigInfo(
       subscriptionEndsAt?: Date | null;
     }
   ) {
-  const guideLink = 'https://dkurokhtin.github.io/vpn-docs/#/';
   const vpnUrl = user.vpnConfigUrl;
 
   if (!vpnUrl) {
@@ -29,12 +29,7 @@ export async function sendVpnConfigInfo(
     `🔗 *Ссылка для подключения:*\n\`\`\`\n${vpnUrl}\n\`\`\``,
     {
       parse_mode: 'Markdown',
-      ...Markup.inlineKeyboard([
-        [{ text: '🧾 Статус', callback_data: 'status' }],
-        [{ text: '📲 Получить QR-код', callback_data: 'get_qr' }],
-        [{ text: '📖 Инструкция по подключению', url: guideLink }]
-      ])
-      
+      ...mainMenu()
     }
   );
 


### PR DESCRIPTION
## Summary
- centralize menu buttons in `menu.ts`
- show the same inline menu in start, status and config helpers
- expose bot commands using `setMyCommands`

## Testing
- `npm install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683fef0d99c0832e92079da029945ba1