### PR TITLE
Add automatic XUI login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ MONGODB_URI=mongodb://localhost:27017/vpn-bot
 XUI_BASE_URL=https://your-xui-host:port
 XUI_USERNAME=admin
 XUI_PASSWORD=admin
-XUI_SESSION_COOKIE=your-session-cookie
 VPN_HOST=your.vpn.host
 VPN_PUBLIC_KEY=...
 ```
+
+Бот сам выполнит запрос к `/dkvpn/login`, используя `XUI_USERNAME` и
+`XUI_PASSWORD`, и сохранит полученное cookie для дальнейших обращений к API.
 
 ---
 

--- a/src/services/xuiAuth.ts
+++ b/src/services/xuiAuth.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import https from 'https';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+import logger from '../logger';
+
+const XUI_BASE_URL = process.env.XUI_BASE_URL || 'https://185.242.86.253:2053';
+
+const jar = new CookieJar();
+
+const api = wrapper(axios.create({
+  baseURL: XUI_BASE_URL,
+  httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+  jar,
+  withCredentials: true
+}));
+
+let loggedIn = false;
+
+async function login() {
+  const username = process.env.XUI_USERNAME;
+  const password = process.env.XUI_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error('XUI_USERNAME or XUI_PASSWORD is not set');
+  }
+
+  logger.info('🔐 Выполняем авторизацию в XUI...');
+  try {
+    await api.post('/dkvpn/login', { username, password });
+    loggedIn = true;
+    logger.info('✅ Авторизация в XUI успешна');
+  } catch (err) {
+    logger.error({ err }, '❌ Ошибка авторизации в XUI');
+    throw err;
+  }
+}
+
+export async function getAuthenticatedApi() {
+  if (!loggedIn) {
+    await login();
+  }
+  return api;
+}

--- a/src/services/xuiService.ts
+++ b/src/services/xuiService.ts
@@ -1,24 +1,11 @@
-import axios from 'axios';
-import https from 'https';
 import { v4 as uuidv4 } from 'uuid';
 import logger from '../logger';
-const XUI_BASE_URL = process.env.XUI_API || 'https://185.242.86.253:2053';
-
-// Вставь cookie из Postman сюда (только значение, без "3x-ui=" и без ; Path=...)
-const sessionCookie = process.env.XUI_SESSION_COOKIE || '';
+import { getAuthenticatedApi } from './xuiAuth';
 
 export async function authAndRequest() {
-  const api = axios.create({
-    baseURL: XUI_BASE_URL,
-    httpsAgent: new https.Agent({ rejectUnauthorized: false }),
-    headers: {
-      Cookie: sessionCookie
-    }
-  });
-
+  const api = await getAuthenticatedApi();
   // Проверим доступ
   await api.get('/dkvpn/panel/api/inbounds/list');
-
   return api;
 }
 


### PR DESCRIPTION
## Summary
- automate authorization against the XUI panel
- use the new authenticated API helper from VPN bot services
- document that the bot logs in using `XUI_USERNAME` and `XUI_PASSWORD`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install`
- `timeout 5 npm run -s start` *(process terminates due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd0d0800832ebf7d2c46d1c6cc95