### PR TITLE
Use http-cookie-agent for cookie jar support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.9.0",
-        "axios-cookiejar-support": "^6.0.2",
         "dotenv": "^16.5.0",
+        "http-cookie-agent": "^7.0.1",
         "mongoose": "^8.15.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
@@ -171,6 +171,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -224,24 +225,6 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-cookiejar-support": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-6.0.2.tgz",
-      "integrity": "sha512-UO/g6DKfVoxnZkZz1NN669bMDjGV3snZnAZGZqIwEd8FdvFI17/rXLyMBm1j1cgtb2O6Jyi4MJ7ll49NPBEMNg==",
-      "dependencies": {
-        "http-cookie-agent": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/3846masa"
-      },
-      "peerDependencies": {
-        "axios": ">=0.20.0",
-        "tough-cookie": ">=4.0.0"
       }
     },
     "node_modules/bson": {
@@ -649,6 +632,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.1.tgz",
       "integrity": "sha512-lZHFZUdPTw64PdksQac5xbUd4NWjUbyDYnvR//2sbLpcC4UqEUW0x/6O+rDntVzJzJ07QvhtL5XZSC+c5EK+IQ==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.9.0",
-    "axios-cookiejar-support": "^6.0.2",
     "dotenv": "^16.5.0",
     "mongoose": "^8.15.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "qrcode": "^1.5.4",
     "telegraf": "^4.16.3",
+    "http-cookie-agent": "^7.0.1",
     "tough-cookie": "^5.1.2",
     "uuid": "^11.1.0"
   },


### PR DESCRIPTION
## Summary
- swap dynamic import of `axios-cookiejar-support` with direct use of `http-cookie-agent`
- add `http-cookie-agent` dependency
- remove unused `axios-cookiejar-support` dependency

## Testing
- `npx tsc --noEmit`
- `npm run start` *(fails: MongoDB URI not set)*

------
https://chatgpt.com/codex/tasks/task_e_68401aac4e7c832e95c0253029e65751