### PR TITLE
Fix duplicate menu on status action

### DIFF
--- a/src/utils/updateMenu.ts
+++ b/src/utils/updateMenu.ts
@@ -15,14 +15,23 @@ export async function updateMenu(
       await ctx.editMessageText(text, extra);
       (ctx.session as any).menuMessageId = ctx.callbackQuery.message.message_id;
       return;
-    } catch (_) {}
+    } catch (err: any) {
+      // Ignore "message is not modified" errors to avoid sending duplicate menus
+      if (err.description?.includes('message is not modified')) {
+        return;
+      }
+    }
   }
 
   if (chatId && storedId) {
     try {
       await ctx.telegram.editMessageText(chatId, storedId, undefined, text, extra);
       return;
-    } catch (_) {}
+    } catch (err: any) {
+      if (err.description?.includes('message is not modified')) {
+        return;
+      }
+    }
   }
 
   if (chatId) {


### PR DESCRIPTION
## Summary
- avoid sending new menu message when Telegram reports *message is not modified*

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6840300a43f4832eb5600bd0e4552117