### PR TITLE
Add privacy policy acceptance flow for existing users

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,9 @@ import logger from './logger';
 import './db';
 import './bot';
 import { disableExpiredClients } from './services/disableExpiredClients';
+import { notifyPolicyToUsers } from './services/notifyPolicy';
 
 setInterval(disableExpiredClients, 1000 * 60 * 10); // каждые 10 минут
 
 logger.info('🕒 Проверка подписок будет выполняться каждые 10 минут');
+notifyPolicyToUsers().catch(() => {});

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -17,6 +17,10 @@ export async function acceptPolicy(ctx: BotContext) {
   if (!telegramId) return ctx.reply('Ошибка: не удалось получить ваш Telegram ID');
 
   if (ctx.state.user) {
+    if (!ctx.state.user.acceptedPolicy) {
+      ctx.state.user.acceptedPolicy = true;
+      await ctx.state.user.save();
+    }
     return statusCommand(ctx);
   }
 
@@ -33,6 +37,7 @@ export async function acceptPolicy(ctx: BotContext) {
       balance: 0,
       subscriptionEndsAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 дней
       xrayUuid: uuid,
+      acceptedPolicy: true,
       vpnConfigUrl: vpnLink,
     });
 
@@ -60,7 +65,9 @@ export async function startCommand(ctx: BotContext) {
   if (!telegramId) return ctx.reply('Ошибка: не удалось получить ваш Telegram ID');
 
   if (ctx.state.user) {
-    return statusCommand(ctx);
+    if (ctx.state.user.acceptedPolicy) {
+      return statusCommand(ctx);
+    }
   }
 
   const username = ctx.from?.username || `user_${telegramId}`;

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -8,6 +8,7 @@ const userSchema = new Schema({
   subscriptionEndsAt: Date,
   vpnConfigUrl: String,
   xrayUuid: String,
+  acceptedPolicy: { type: Boolean, default: false },
   createdAt: { type: Date, default: Date.now },
   disabled: { type: Boolean, default: false },
 });

--- a/src/services/notifyPolicy.ts
+++ b/src/services/notifyPolicy.ts
@@ -1,0 +1,31 @@
+import User from '../db/models/User';
+import logger from '../logger';
+import { bot } from '../bot';
+import { Markup } from 'telegraf';
+
+export async function notifyPolicyToUsers() {
+  const privacyLink =
+    'https://github.com/dkurokhtin/vpn-docs/blob/main/vpn_legal_docs.md';
+
+  const users = await User.find({ acceptedPolicy: { $ne: true } });
+  logger.info(`🔔 Напоминание о политике для ${users.length} пользователей`);
+
+  for (const user of users) {
+    if (!user.telegramId) continue;
+    try {
+      await bot.telegram.sendMessage(
+        user.telegramId,
+        '📄 Пожалуйста, ознакомьтесь с нашей политикой конфиденциальности',
+        {
+          reply_markup: Markup.inlineKeyboard([
+            [Markup.button.url('📄 Политика конфиденциальности', privacyLink)],
+            [Markup.button.callback('✅ Я согласен', 'accept_policy')]
+          ]).reply_markup,
+          parse_mode: 'Markdown'
+        }
+      );
+    } catch (err) {
+      logger.error({ err }, `❌ Ошибка отправки политики ${user.telegramId}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `acceptedPolicy` field to User model
- prompt existing users to accept privacy policy
- mark new users as having accepted policy
- notify all users to accept policy on startup

## Testing
- `npx tsc --noEmit` *(fails: cannot find module declarations)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68409a654bb0832eacc95184e7a10ec2