### PR TITLE
Fix privacy policy reminders

### DIFF
--- a/src/bot/middleware/loadUser.ts
+++ b/src/bot/middleware/loadUser.ts
@@ -10,6 +10,10 @@ export const loadUser: MiddlewareFn<BotContext> = async (ctx, next) => {
   const user = await User.findOne({ telegramId });
   if (user) {
     ctx.state.user = user;
+    if (user.acceptedPolicy !== true && (user.vpnConfigUrl || user.xrayUuid)) {
+      user.acceptedPolicy = true;
+      await user.save();
+    }
   }
 
   return next();


### PR DESCRIPTION
## Summary
- auto-mark old accounts as having accepted the privacy policy in `loadUser`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a0a138ec832e90d87f4fb8c851f1