### PR TITLE
fix menu not shown after commands

### DIFF
--- a/src/bot/middleware/loadUser.ts
+++ b/src/bot/middleware/loadUser.ts
@@ -3,14 +3,10 @@ import { BotContext } from '../context';
 import User from '../../db/models/User';
 import logger from '../../logger';
 
-
 export const loadUser: MiddlewareFn<BotContext> = async (ctx, next) => {
   const telegramId = ctx.from?.id;
   if (!telegramId) return next();
 
-  const user = await User.findOne({ telegramId });
-  if (user) {
-    ctx.state.user = user;
   try {
     const user = await User.findOne({ telegramId });
     if (user) {

--- a/src/utils/updateMenu.ts
+++ b/src/utils/updateMenu.ts
@@ -30,10 +30,10 @@ export async function updateMenu(
       await ctx.telegram.editMessageText(chatId, storedId, undefined, text, extra);
       return;
     } catch (err: any) {
-      if (err.description?.includes('message is not modified')) {
-        return;
+      // If the message wasn't modified, still send a new one for convenience
+      if (!err.description?.includes('message is not modified')) {
+        delete (ctx.session as any).menuMessageId;
       }
-      delete (ctx.session as any).menuMessageId;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure session middleware is well-formed
- always send a new menu message when `/status` or `/start` repeat

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6619808832e925682cbebe9774d