### PR TITLE
Fix logging for client creation failures

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -53,7 +53,7 @@ export async function acceptPolicy(ctx: BotContext) {
       ])
     );
   } catch (error: any) {
-    logger.error('❌ Ошибка при создании клиента в XUI:', error.message);
+    logger.error({ err: error }, '❌ Ошибка при создании клиента в XUI');
     return ctx.reply('❌ Не удалось создать VPN-доступ. Обратитесь в поддержку.');
   }
 }


### PR DESCRIPTION
## Summary
- capture stack info in XUI client creation error logging

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840c264bcc4832eb449c81039a33935