### PR TITLE
Add axios retry and warmup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.9.0",
+        "axios-retry": "^3.9.1",
         "dotenv": "^16.5.0",
         "http-cookie-agent": "^7.0.1",
         "mongoose": "^8.15.0",
@@ -25,6 +26,15 @@
         "@types/qrcode": "^1.5.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -225,6 +235,16 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
+      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/bson": {
@@ -658,6 +678,18 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/joycon": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.9.0",
+    "axios-retry": "^3.9.1",
     "dotenv": "^16.5.0",
     "mongoose": "^8.15.0",
     "pino": "^9.6.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,10 @@ import './db';
 import './bot';
 import { disableExpiredClients } from './services/disableExpiredClients';
 import { notifyPolicyToUsers } from './services/notifyPolicy';
+import { warmupXuiApi } from './services/xuiAuth';
 
 setInterval(disableExpiredClients, 1000 * 60 * 10); // каждые 10 минут
 
 logger.info('🕒 Проверка подписок будет выполняться каждые 10 минут');
 notifyPolicyToUsers().catch(() => {});
+warmupXuiApi().catch(() => {});

--- a/src/services/xuiAuth.ts
+++ b/src/services/xuiAuth.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import axiosRetry from 'axios-retry';
 import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http';
 import { CookieJar } from 'tough-cookie';
 import logger from '../logger';
@@ -10,13 +11,20 @@ let apiPromise: Promise<AxiosInstance> | null = null;
 function createApi(): AxiosInstance {
   const jar = new CookieJar();
 
-  return axios.create({
+  const instance = axios.create({
     baseURL: XUI_BASE_URL,
     httpAgent: new HttpCookieAgent({ cookies: { jar } }),
     httpsAgent: new HttpsCookieAgent({ cookies: { jar }, rejectUnauthorized: false }),
     withCredentials: true,
-    timeout: 5000  
+    timeout: 5000
   });
+
+  axiosRetry(instance, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+  });
+
+  return instance;
 }
 
 async function getApi(): Promise<AxiosInstance> {
@@ -49,4 +57,13 @@ export async function getAuthenticatedApi() {
     await login();
   }
   return await getApi();
+}
+
+// Выполняем логин при старте приложения, чтобы прогреть API
+export async function warmupXuiApi(): Promise<void> {
+  try {
+    await login();
+  } catch (err) {
+    logger.warn({ err }, '⚠️ Не удалось прогреть XUI API при старте');
+  }
 }


### PR DESCRIPTION
## Summary
- add `axios-retry` dependency
- retry XUI requests and prewarm API on start

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6840c529d9b0832e87fe7a644144bf30