### PR TITLE
Fix double DB connection

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,6 +1,6 @@
 import { Telegraf } from 'telegraf';
 import { BotContext } from './context';
-import { BOT_TOKEN, MONGODB_URI } from '../config';
+import { BOT_TOKEN } from '../config';
 import { startCommand, acceptPolicy } from './commands/start';
 import { statusCommand } from './commands/status';
 import { balanceCommand } from './commands/balance';
@@ -22,9 +22,6 @@ export function registerActions(bot: Telegraf<BotContext>) {
   }
 
 export const bot = new Telegraf<BotContext>(BOT_TOKEN);
-mongoose.connect(MONGODB_URI, {
-  dbName: 'vpn-bot',
-});
 bot.use(mongooseSession);
  // Лог всех входящих апдейтов (сообщения, команды, кнопки)
 bot.use((ctx, next) => {


### PR DESCRIPTION
## Summary
- remove redundant mongoose connect from bot startup to avoid double DB connection

## Testing
- `npm run start` *(fails: BOT_TOKEN is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68413b332780832ebf403406b64029c4