### PR TITLE
Fix start command launch order

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,21 @@
 import logger from './logger';
 
-import './db';
-import './bot';
+import { connectDb } from './db';
+import { launchBot } from './bot';
 import { disableExpiredClients } from './services/disableExpiredClients';
 import { notifyPolicyToUsers } from './services/notifyPolicy';
 import { warmupXuiApi } from './services/xuiAuth';
 
-setInterval(disableExpiredClients, 1000 * 60 * 10); // каждые 10 минут
+async function init() {
+  await connectDb();
+  await warmupXuiApi();
+  await launchBot();
 
-logger.info('🕒 Проверка подписок будет выполняться каждые 10 минут');
-notifyPolicyToUsers().catch(() => {});
-warmupXuiApi().catch(() => {});
+  setInterval(disableExpiredClients, 1000 * 60 * 10); // каждые 10 минут
+  logger.info('🕒 Проверка подписок будет выполняться каждые 10 минут');
+  notifyPolicyToUsers().catch(() => {});
+}
+
+init().catch((err) => {
+  logger.error({ err }, 'Failed to initialize application');
+});

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -10,7 +10,6 @@ import logger from '../logger';
 import wrapCallbackAction from '../utils/wrapCallbackAction';
 import { configCommand } from './commands/config';
 import { loadUser } from './middleware/loadUser';
-import mongoose from 'mongoose';
 import { mongooseSession } from '../session';
 
 export function registerActions(bot: Telegraf<BotContext>) {
@@ -58,7 +57,7 @@ bot.command('extend', extendCommand);
 registerActions(bot);
 
 // ✅ Запуск с повторными попытками при ошибке
-async function launchBot(attempt = 0): Promise<void> {
+export async function launchBot(attempt = 0): Promise<void> {
   try {
     await bot.launch();
     logger.info('🚀 Бот запущен');
@@ -76,8 +75,6 @@ async function launchBot(attempt = 0): Promise<void> {
     }
   }
 }
-
-launchBot().catch(() => {});
 
 // ✅ Глобальный перехват ошибок
 process.on('unhandledRejection', (reason) => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,10 +1,13 @@
 import mongoose from 'mongoose';
 import { MONGODB_URI } from '../config';
 
-mongoose
-  .connect(MONGODB_URI)
-  .then(() => console.log('MongoDB connected'))
-  .catch((err) => {
+export async function connectDb(): Promise<void> {
+  try {
+    await mongoose.connect(MONGODB_URI);
+    console.log('MongoDB connected');
+  } catch (err) {
     console.error('MongoDB connection error:', err);
     process.exit(1);
-  });
+  }
+}
+


### PR DESCRIPTION
## Summary
- ensure MongoDB is connected before starting the bot
- expose `launchBot` function and start it from `app.ts`
- warm up XUI API before launching

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684143d89268832e94c9f86c9ffd1b92