### PR TITLE
Fix start command reliability

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -75,10 +75,18 @@ export async function startCommand(ctx: BotContext) {
   if (!telegramId) return ctx.reply('Ошибка: не удалось получить ваш Telegram ID');
 
   try {
-    if (ctx.state.user) {
-      if (ctx.state.user.acceptedPolicy) {
-        return statusCommand(ctx);
+    let user = ctx.state.user;
+
+    if (!user) {
+      user = await User.findOne({ telegramId });
+      if (user) {
+        ctx.state.user = user;
       }
+    }
+
+    if (user?.acceptedPolicy) {
+      await statusCommand(ctx);
+      return;
     }
   } catch (err) {
     logger.error({ err }, 'Failed to handle start command');


### PR DESCRIPTION
## Summary
- make start command fetch `User` directly if not already loaded
- await `statusCommand` to properly handle its errors

## Testing
- `npx tsc --noEmit` *(fails: cannot find module declarations)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68414ae6cd64832e8ac4baca6a200eb7