### PR TITLE
Fix start command update

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -74,6 +74,9 @@ export async function startCommand(ctx: BotContext) {
 
   if (!telegramId) return ctx.reply('Ошибка: не удалось получить ваш Telegram ID');
 
+  // Всегда отправляем новое приветствие, чтобы пользователь видел ответ внизу чата
+  delete (ctx.session as any).menuMessageId;
+
   try {
     let user = ctx.state.user;
 


### PR DESCRIPTION
## Summary
- reset stored menu id before sending `/start` reply so message always shows

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68414c7ac8f8832eb9c9efbe3a28c5e6