### PR TITLE
Fix acceptPolicy menu placement

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -59,7 +59,8 @@ export async function acceptPolicy(ctx: BotContext) {
       Markup.inlineKeyboard([
         [Markup.button.callback('⚙️ Статус', 'status')],
         [Markup.button.url('📖 Инструкция по подключению', guideLink)],
-      ])
+      ]),
+      { forceNew: true }
     );
   } catch (error: any) {
     logger.error({ err: error }, '❌ Ошибка при создании клиента в XUI');
@@ -73,6 +74,9 @@ export async function startCommand(ctx: BotContext) {
   const telegramId = ctx.from?.id;
 
   if (!telegramId) return ctx.reply('Ошибка: не удалось получить ваш Telegram ID');
+
+  // Всегда отправляем новое приветствие, чтобы пользователь видел ответ внизу чата
+  delete (ctx.session as any).menuMessageId;
 
   try {
     let user = ctx.state.user;

--- a/src/utils/updateMenu.ts
+++ b/src/utils/updateMenu.ts
@@ -4,11 +4,23 @@ import { BotContext } from '../bot/context';
 export async function updateMenu(
   ctx: BotContext,
   text: string,
-  keyboard: ReturnType<typeof Markup.inlineKeyboard>
+  keyboard: ReturnType<typeof Markup.inlineKeyboard>,
+  options?: { forceNew?: boolean }
 ) {
+  const forceNew = options?.forceNew;
   const extra = { parse_mode: 'Markdown', reply_markup: keyboard.reply_markup } as any;
   const chatId = ctx.chat?.id;
   const storedId = (ctx.session as any)?.menuMessageId;
+
+  if (forceNew) {
+    if (chatId) {
+      const msg = await ctx.telegram.sendMessage(chatId, text, extra);
+      (ctx.session as any).menuMessageId = msg.message_id;
+    } else {
+      await ctx.reply(text, extra);
+    }
+    return;
+  }
 
   if (ctx.callbackQuery && 'message' in ctx.callbackQuery && ctx.callbackQuery.message) {
     try {
@@ -16,9 +28,18 @@ export async function updateMenu(
       (ctx.session as any).menuMessageId = ctx.callbackQuery.message.message_id;
       return;
     } catch (err: any) {
-      // Ignore "message is not modified" errors to avoid sending duplicate menus
       if (err.description?.includes('message is not modified')) {
-        return;
+        // try to update the keyboard even if text didn't change
+        try {
+          await ctx.editMessageReplyMarkup(extra.reply_markup);
+          (ctx.session as any).menuMessageId = ctx.callbackQuery.message.message_id;
+          return;
+        } catch (err2: any) {
+          // Ignore if nothing changed
+          if (err2.description?.includes('message is not modified')) {
+            return;
+          }
+        }
       }
       // remove invalid stored message id so we can send a fresh message
       delete (ctx.session as any).menuMessageId;
@@ -30,6 +51,17 @@ export async function updateMenu(
       await ctx.telegram.editMessageText(chatId, storedId, undefined, text, extra);
       return;
     } catch (err: any) {
+      if (err.description?.includes('message is not modified')) {
+        // update keyboard when text stays the same
+        try {
+          await ctx.telegram.editMessageReplyMarkup(chatId, storedId, undefined, extra.reply_markup);
+          return;
+        } catch (err2: any) {
+          if (err2.description?.includes('message is not modified')) {
+            return;
+          }
+        }
+      }
       // If the message wasn't modified, still send a new one for convenience
       if (!err.description?.includes('message is not modified')) {
         delete (ctx.session as any).menuMessageId;


### PR DESCRIPTION
## Summary
- support `forceNew` option in `updateMenu`
- send a fresh welcome message after policy acceptance

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'pino')*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68414c7ac8f8832eb9c9efbe3a28c5e6